### PR TITLE
Splitter

### DIFF
--- a/1_fetch/src/get_site_data.R
+++ b/1_fetch/src/get_site_data.R
@@ -1,7 +1,7 @@
 # download data for each site
 # packages needed: tidyverse, dataRetrieval
-get_site_data <- function(sites_info, state, parameter) {
-  site_info <- filter(sites_info, state_cd == state)
+get_site_data <- function(site_info, state, parameter) {
+  #site_info <- filter(sites_info, state_cd == state)
   message(sprintf('  Retrieving data for %s-%s', state, state))
 
   # simulate an unreliable web service or internet connection by causing random failures

--- a/1_fetch/src/get_state_inventory.R
+++ b/1_fetch/src/get_state_inventory.R
@@ -1,0 +1,3 @@
+get_state_inventory <- function(sites_info, state) {
+  site_info <- dplyr::filter(sites_info, state_cd == state)
+}

--- a/_targets.R
+++ b/_targets.R
@@ -13,7 +13,7 @@ source("1_fetch/src/get_site_data.R")
 source("3_visualize/src/map_sites.R")
 
 # Configuration
-states <- c('WI','MN','MI','IL')
+states <- c('WI','MN','MI','IL','IN','IA')
 parameter <- c('00060')
 
 # Targets

--- a/_targets.R
+++ b/_targets.R
@@ -8,6 +8,7 @@ tar_option_set(packages = c("tidyverse", "dataRetrieval", "urbnmapr", "rnaturale
 
 # Load functions needed by targets below
 source("1_fetch/src/find_oldest_sites.R")
+source("1_fetch/src/get_state_inventory.R")
 source("1_fetch/src/get_site_data.R")
 source("3_visualize/src/map_sites.R")
 
@@ -19,20 +20,11 @@ parameter <- c('00060')
 list(
   # Identify oldest sites
   tar_target(oldest_active_sites, find_oldest_sites(states, parameter)),
-
-  # PULL SITE DATA HERE
-  #Wisconsin
-  #tar_target(wi_data,get_site_data(oldest_active_sites, states[1], parameter)),
-  #Minnesota
-  #tar_target(mn_data, get_site_data(oldest_active_sites, states[2], parameter)),
-  #Michigan
-  #tar_target(mi_data, get_site_data(oldest_active_sites, states[3], parameter)),
-
+  # insert branching step
   tar_map(
     values = tibble(state_abb = states),
-    tar_target(nwis_data, get_site_data(oldest_active_sites, state_abb, parameter))
-    # Insert step for tallying data here
-    # Insert step for plotting data here
+    tar_target(nwis_inventory, get_state_inventory(sites_info = oldest_active_sites, state_abb)),
+    tar_target(nwis_data, get_site_data(nwis_inventory, state_abb, parameter))
   ),
 
   # Map oldest sites


### PR DESCRIPTION
added splitter function with updated states `"IA"` and `"IN"`, targets that got rebuilt when I added new states were `oldest_active_sites` and all the `nwis_inventory_stateID` targets, those that got skipped were `nwis_data_stateID`